### PR TITLE
Add query collector

### DIFF
--- a/examples/promsql/query_collector/main.go
+++ b/examples/promsql/query_collector/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/lab259/go-rscsrv"
+	"github.com/lab259/go-rscsrv-prometheus/examples/promsql/query_collector/services"
+	"github.com/lab259/go-rscsrv-prometheus/promhermes"
+	"github.com/lab259/go-rscsrv-prometheus/promsql"
+	h "github.com/lab259/hermes"
+	"github.com/lab259/hermes/middlewares"
+)
+
+func main() {
+	serviceStarter := rscsrv.DefaultServiceStarter(
+		&services.DefaultPromService,
+		&services.DefaultQueryCollectorService,
+	)
+	if err := serviceStarter.Start(); err != nil {
+		panic(err)
+	}
+
+	router := h.DefaultRouter()
+	router.Use(middlewares.RecoverableMiddleware, middlewares.LoggingMiddleware)
+	router.Get("/metrics", promhermes.Handler(&services.DefaultPromService))
+
+	app := h.NewApplication(h.ApplicationConfig{
+		ServiceStarter: serviceStarter,
+		HTTP: h.FasthttpServiceConfiguration{
+			Bind: ":3000",
+		},
+	}, router)
+
+	log.Println("Go to http://localhost:3000/metrics")
+
+	// Updating metrics
+	go func() {
+		psqlInfo := fmt.Sprintf("user=postgres password=postgres dbname=pg-test sslmode=disable")
+		db, err := sql.Open("postgres", psqlInfo)
+		if err != nil {
+			panic(err)
+		}
+		defer db.Close()
+
+		err = db.Ping()
+		if err != nil {
+			panic(err)
+		}
+
+		db.Exec(`DROP TABLE users`)
+
+		_, err = db.Exec(`
+		CREATE TABLE users (
+			id int NOT NULL PRIMARY KEY,
+			name text NOT NULL
+			);
+			
+			INSERT INTO users (id, name)
+			VALUES (1, 'john')
+			`)
+		if err != nil {
+			panic(err)
+		}
+
+		usersQuery := services.DefaultQueryCollectorService.NewNamedQuery("users")
+
+		usersSQL := promsql.NewSQLQuery(usersQuery, db)
+
+		for {
+			time.Sleep(3 * time.Second)
+			opt := rand.Intn(100)
+
+			if opt <= 50 {
+				log.Println("Executing correct query")
+				_, err := usersSQL.Query("select name from users")
+				if err != nil {
+					panic(err)
+				}
+
+			} else {
+				log.Println("Executing failing query")
+				usersSQL.Query("wrong query")
+			}
+		}
+	}()
+	app.Start()
+}

--- a/examples/promsql/query_collector/services/prometheus.go
+++ b/examples/promsql/query_collector/services/prometheus.go
@@ -1,0 +1,20 @@
+package services
+
+import (
+	promsrv "github.com/lab259/go-rscsrv-prometheus"
+)
+
+var DefaultPromService PromService
+
+type PromService struct {
+	promsrv.Service
+}
+
+// Name implements the rscsrv.Service interface.
+func (srv *PromService) Name() string {
+	return "Prometheus Service"
+}
+
+func (service *PromService) Start() error {
+	return nil
+}

--- a/examples/promsql/query_collector/services/query_collector.go
+++ b/examples/promsql/query_collector/services/query_collector.go
@@ -1,0 +1,38 @@
+package services
+
+import (
+	"github.com/lab259/go-rscsrv-prometheus/promquery"
+	_ "github.com/lib/pq"
+)
+
+var DefaultQueryCollectorService QueryCollectorService
+
+type QueryCollectorService struct {
+	*promquery.QueryCollector
+}
+
+// Name implements the rscsrv.Service interface.
+func (srv *QueryCollectorService) Name() string {
+	return "Query Collector Service"
+}
+
+func (service *QueryCollectorService) Start() error {
+	service.QueryCollector = promquery.NewQueryCollector(&promquery.QueryCollectorOpts{
+		Prefix: "query_collector",
+	})
+
+	return DefaultPromService.Register(service.QueryCollector)
+}
+
+// Restart restarts the Prometheus service.
+func (service *QueryCollectorService) Restart() error {
+	if err := service.Stop(); err != nil {
+		return err
+	}
+	return service.Start()
+}
+
+// Stop stops the Prometheus service.
+func (service *QueryCollectorService) Stop() error {
+	return nil
+}

--- a/promquery/named_query.go
+++ b/promquery/named_query.go
@@ -1,0 +1,14 @@
+package promquery
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type NamedQueryCollector struct {
+	parent        *QueryCollector
+	name          string
+	TotalCalls    prometheus.Counter
+	TotalDuration prometheus.Counter
+	TotalSuccess  prometheus.Counter
+	TotalFailures prometheus.Counter
+}

--- a/promquery/query_collector.go
+++ b/promquery/query_collector.go
@@ -1,0 +1,122 @@
+package promquery
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// QueryCollector is responsible for concentrate all metrics avaiable
+type QueryCollector struct {
+	totalCalls    *prometheus.CounterVec
+	totalDuration *prometheus.CounterVec
+	totalSuccess  *prometheus.CounterVec
+	totalFailures *prometheus.CounterVec
+}
+
+// QueryCollectorOpts is the input option for QueryCollector
+type QueryCollectorOpts struct {
+	// Prefix: responsible for all counters descs prefix
+	Prefix string
+}
+
+var queryCollectorLabels = []string{"queryName"}
+
+// NewQueryCollector returns a new QueryCollector pointer
+func NewQueryCollector(opts *QueryCollectorOpts) *QueryCollector {
+	prefix := opts.Prefix
+	if prefix != "" && !strings.HasSuffix(opts.Prefix, "_") {
+		prefix += "_"
+	}
+
+	// TODO: Add prefix name and descriptions
+	return &QueryCollector{
+		totalCalls: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "",
+				Help: "",
+			},
+			queryCollectorLabels,
+		),
+		totalDuration: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "",
+				Help: "",
+			},
+			queryCollectorLabels,
+		),
+		totalSuccess: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "",
+				Help: "",
+			},
+			queryCollectorLabels,
+		),
+		totalFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "",
+				Help: "",
+			},
+			queryCollectorLabels,
+		),
+	}
+}
+
+// NewNamedQuery returns a new NamedQueryCollector pointer
+func (collector *QueryCollector) NewNamedQuery(name string) *NamedQueryCollector {
+	return &NamedQueryCollector{
+		parent:        collector,
+		name:          name,
+		TotalCalls:    collector.totalCalls.WithLabelValues(name),
+		TotalDuration: collector.totalDuration.WithLabelValues(name),
+		TotalSuccess:  collector.totalSuccess.WithLabelValues(name),
+		TotalFailures: collector.totalFailures.WithLabelValues(name),
+	}
+}
+
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once
+// the last descriptor has been sent. The sent descriptors fulfill the
+// consistency and uniqueness requirements described in the Desc
+// documentation.
+//
+// It is valid if one and the same Collector sends duplicate
+// descriptors. Those duplicates are simply ignored. However, two
+// different Collectors must not send duplicate descriptors.
+//
+// Sending no descriptor at all marks the Collector as “unchecked”,
+// i.e. no checks will be performed at registration time, and the
+// Collector may yield any Metric it sees fit in its Collect method.
+//
+// This method idempotently sends the same descriptors throughout the
+// lifetime of the Collector. It may be called concurrently and
+// therefore must be implemented in a concurrency safe way.
+//
+// If a Collector encounters an error while executing this method, it
+// must send an invalid descriptor (created with NewInvalidDesc) to
+// signal the error to the registry.
+func (collector *QueryCollector) Describe(ch chan<- *prometheus.Desc) {
+	collector.totalCalls.Describe(ch)
+	collector.totalDuration.Describe(ch)
+	collector.totalSuccess.Describe(ch)
+	collector.totalFailures.Describe(ch)
+}
+
+// Collect is called by the Prometheus registry when collecting
+// metrics. The implementation sends each collected metric via the
+// provided channel and returns once the last metric has been sent. The
+// descriptor of each sent metric is one of those returned by Describe
+// (unless the Collector is unchecked, see above). Returned metrics that
+// share the same descriptor must differ in their variable label
+// values.
+//
+// This method may be called concurrently and must therefore be
+// implemented in a concurrency safe way. Blocking occurs at the expense
+// of total performance of rendering all registered metrics. Ideally,
+// Collector implementations support concurrent readers.
+func (collector *QueryCollector) Collect(metrics chan<- prometheus.Metric) {
+	collector.totalCalls.Collect(metrics)
+	collector.totalDuration.Collect(metrics)
+	collector.totalSuccess.Collect(metrics)
+	collector.totalFailures.Collect(metrics)
+}

--- a/promquery/query_collector.go
+++ b/promquery/query_collector.go
@@ -1,6 +1,7 @@
 package promquery
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,29 +34,29 @@ func NewQueryCollector(opts *QueryCollectorOpts) *QueryCollector {
 	return &QueryCollector{
 		totalCalls: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "",
-				Help: "",
+				Name: fmt.Sprintf("db_%stotal_calls", prefix),
+				Help: "The total number of calls from a query",
 			},
 			queryCollectorLabels,
 		),
 		totalDuration: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "",
-				Help: "",
+				Name: fmt.Sprintf("db_%stotal_duration", prefix),
+				Help: "The total duration (in seconds) from a query processed",
 			},
 			queryCollectorLabels,
 		),
 		totalSuccess: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "",
-				Help: "",
+				Name: fmt.Sprintf("db_%stotal_success", prefix),
+				Help: "The total number of a query processed with success",
 			},
 			queryCollectorLabels,
 		),
 		totalFailures: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "",
-				Help: "",
+				Name: fmt.Sprintf("db_%stotal_failures", prefix),
+				Help: "The total number of a query processed with failure",
 			},
 			queryCollectorLabels,
 		),

--- a/promquery/query_collector.go
+++ b/promquery/query_collector.go
@@ -21,7 +21,7 @@ type QueryCollectorOpts struct {
 	Prefix string
 }
 
-var queryCollectorLabels = []string{"queryName"}
+var queryCollectorLabels = []string{"name"}
 
 // NewQueryCollector returns a new QueryCollector pointer
 func NewQueryCollector(opts *QueryCollectorOpts) *QueryCollector {
@@ -34,28 +34,28 @@ func NewQueryCollector(opts *QueryCollectorOpts) *QueryCollector {
 	return &QueryCollector{
 		totalCalls: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("db_%stotal_calls", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_calls", prefix),
 				Help: "The total number of calls from a query",
 			},
 			queryCollectorLabels,
 		),
 		totalDuration: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("db_%stotal_duration", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_duration", prefix),
 				Help: "The total duration (in seconds) from a query processed",
 			},
 			queryCollectorLabels,
 		),
 		totalSuccess: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("db_%stotal_success", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_success", prefix),
 				Help: "The total number of a query processed with success",
 			},
 			queryCollectorLabels,
 		),
 		totalFailures: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("db_%stotal_failures", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_failures", prefix),
 				Help: "The total number of a query processed with failure",
 			},
 			queryCollectorLabels,

--- a/promsql/sql_query.go
+++ b/promsql/sql_query.go
@@ -1,0 +1,58 @@
+package promsql
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/lab259/go-rscsrv-prometheus/promquery"
+)
+
+type PromSQLQuery struct {
+	namedQuery *promquery.NamedQueryCollector
+	db         DBProxy
+}
+
+func NewSQLQuery(namedQuery *promquery.NamedQueryCollector, db DBProxy) *PromSQLQuery {
+	return &PromSQLQuery{
+		namedQuery: namedQuery,
+		db:         db,
+	}
+}
+
+type DBProxy interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+func (srv *PromSQLQuery) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	srv.namedQuery.TotalCalls.Inc()
+
+	start := time.Now()
+	res, err := srv.db.Query(query, args...)
+	srv.namedQuery.TotalDuration.Add(time.Since(start).Seconds())
+
+	if err != nil {
+		srv.namedQuery.TotalFailures.Inc()
+	} else {
+		srv.namedQuery.TotalSuccess.Inc()
+	}
+
+	return res, err
+}
+
+func (srv *PromSQLQuery) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	srv.namedQuery.TotalCalls.Inc()
+
+	start := time.Now()
+	res, err := srv.db.QueryContext(ctx, query, args...)
+	srv.namedQuery.TotalDuration.Add(time.Since(start).Seconds())
+
+	if err != nil {
+		srv.namedQuery.TotalFailures.Inc()
+	} else {
+		srv.namedQuery.TotalSuccess.Inc()
+	}
+
+	return res, err
+}

--- a/promsql/sql_query_test.go
+++ b/promsql/sql_query_test.go
@@ -1,0 +1,162 @@
+package promsql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/lab259/go-rscsrv-prometheus/ginkgotest"
+	"github.com/lab259/go-rscsrv-prometheus/promquery"
+	_ "github.com/lib/pq"
+)
+
+func TestPromsqlSQLQuery(t *testing.T) {
+	ginkgotest.Init("Promsql PromSQLQuery Test Suite", t)
+}
+
+var _ = Describe("PromSQLQuery", func() {
+
+	var dbInfo = fmt.Sprintf("user=postgres password=postgres dbname=pg-test sslmode=disable")
+	var dbDriverName = "postgres"
+
+	BeforeEach(func() {
+		db, err := sql.Open(dbDriverName, dbInfo)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(db.Ping()).ShouldNot(HaveOccurred())
+
+		defer db.Close()
+
+		_, err = db.Exec(`
+		CREATE TABLE users (
+			id int NOT NULL PRIMARY KEY,
+			name text NOT NULL
+		);
+
+		INSERT INTO users (id, name)
+		VALUES (1, 'john')
+		`)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		db, err := sql.Open(dbDriverName, dbInfo)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(db.Ping()).ShouldNot(HaveOccurred())
+		defer db.Close()
+
+		_, err = db.Exec(`
+		DROP TABLE users`)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	When("using Query", func() {
+
+		var parentQueryCollector *promquery.QueryCollector
+		var usersNamedQuery *promquery.NamedQueryCollector
+		BeforeEach(func() {
+			parentQueryCollector = promquery.NewQueryCollector(&promquery.QueryCollectorOpts{})
+			usersNamedQuery = parentQueryCollector.NewNamedQuery("users")
+		})
+
+		It("should increase success to 1", func() {
+			db, err := sql.Open("postgres", dbInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(db.Ping()).ShouldNot(HaveOccurred())
+
+			promSQL := NewSQLQuery(usersNamedQuery, db)
+
+			rows, err := promSQL.Query("select name from users where id = 1")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer rows.Close()
+
+			var metric dto.Metric
+			Expect(usersNamedQuery.TotalCalls.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalSuccess.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalFailures.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(0))
+			Expect(usersNamedQuery.TotalDuration.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically(">", 0))
+		})
+
+		It("should increase failures to 1", func() {
+			db, err := sql.Open("postgres", dbInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(db.Ping()).ShouldNot(HaveOccurred())
+
+			promSQL := NewSQLQuery(usersNamedQuery, db)
+
+			_, err = promSQL.Query("wrong query")
+			Expect(err).Should(HaveOccurred())
+
+			var metric dto.Metric
+			Expect(usersNamedQuery.TotalCalls.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalSuccess.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(0))
+			Expect(usersNamedQuery.TotalFailures.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalDuration.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically(">", 0))
+		})
+	})
+
+	When("using QueryContext", func() {
+
+		var parentQueryCollector *promquery.QueryCollector
+		var usersNamedQuery *promquery.NamedQueryCollector
+		BeforeEach(func() {
+			parentQueryCollector = promquery.NewQueryCollector(&promquery.QueryCollectorOpts{})
+			usersNamedQuery = parentQueryCollector.NewNamedQuery("users")
+		})
+
+		It("should increase success to 1", func() {
+			db, err := sql.Open("postgres", dbInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(db.Ping()).ShouldNot(HaveOccurred())
+
+			promSQL := NewSQLQuery(usersNamedQuery, db)
+
+			rows, err := promSQL.QueryContext(context.Background(), "select name from users where id = 1")
+			Expect(err).ShouldNot(HaveOccurred())
+			defer rows.Close()
+
+			var metric dto.Metric
+			Expect(usersNamedQuery.TotalCalls.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalSuccess.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalFailures.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(0))
+			Expect(usersNamedQuery.TotalDuration.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically(">", 0))
+		})
+
+		It("should increase failures to 1", func() {
+			db, err := sql.Open("postgres", dbInfo)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(db.Ping()).ShouldNot(HaveOccurred())
+
+			promSQL := NewSQLQuery(usersNamedQuery, db)
+
+			_, err = promSQL.QueryContext(context.Background(), "wrong query")
+			Expect(err).Should(HaveOccurred())
+
+			var metric dto.Metric
+			Expect(usersNamedQuery.TotalCalls.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalSuccess.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(0))
+			Expect(usersNamedQuery.TotalFailures.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeEquivalentTo(1))
+			Expect(usersNamedQuery.TotalDuration.Write(&metric)).To(Succeed())
+			Expect(metric.GetCounter().GetValue()).To(BeNumerically(">", 0))
+		})
+	})
+})


### PR DESCRIPTION
### :sparkles: Enhancements

* Add QueryCollector to capture metrics from a specific query (i.e. `NamedQuery`)

### :pencil: Documentation

* Add a QueryCollector usage example with hermes
