### PR TITLE
Refactor QueryCollector and NamedQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ vendor
 coverage.txt
 test-results/
 *.coverprofile
+
+.history

--- a/examples/promsql/query_collector/main.go
+++ b/examples/promsql/query_collector/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lab259/go-rscsrv"
 	"github.com/lab259/go-rscsrv-prometheus/examples/promsql/query_collector/services"
 	"github.com/lab259/go-rscsrv-prometheus/promhermes"
-	"github.com/lab259/go-rscsrv-prometheus/promsql"
 	h "github.com/lab259/hermes"
 	"github.com/lab259/hermes/middlewares"
 )
@@ -66,13 +65,13 @@ func main() {
 			panic(err)
 		}
 
-		usersQuery := services.DefaultQueryCollectorService.NewNamedQuery("users_query")
-		usersInsert := services.DefaultQueryCollectorService.NewNamedQuery("users_insert")
-		usersDelete := services.DefaultQueryCollectorService.NewNamedQuery("users_delete")
+		usersQuery := services.DefaultQueryCollectorService.NamedQuery("users_query")
+		usersInsert := services.DefaultQueryCollectorService.NamedQuery("users_insert")
+		usersDelete := services.DefaultQueryCollectorService.NamedQuery("users_delete")
 
-		usersQuerySQL := promsql.NewSQLQuery(usersQuery, db)
-		usersInsertSQL := promsql.NewSQLQuery(usersInsert, db)
-		usersDeleteSQL := promsql.NewSQLQuery(usersDelete, db)
+		usersQuerySQL := usersQuery(db)
+		usersInsertSQL := usersInsert(db)
+		usersDeleteSQL := usersDelete(db)
 
 		var lastInsertedID int64 = 1
 		var lastDeletedID int64 = 1

--- a/examples/promsql/query_collector/services/query_collector.go
+++ b/examples/promsql/query_collector/services/query_collector.go
@@ -1,14 +1,14 @@
 package services
 
 import (
-	"github.com/lab259/go-rscsrv-prometheus/promquery"
+	"github.com/lab259/go-rscsrv-prometheus/promsql"
 	_ "github.com/lib/pq"
 )
 
 var DefaultQueryCollectorService QueryCollectorService
 
 type QueryCollectorService struct {
-	*promquery.QueryCollector
+	*promsql.QueryCollector
 }
 
 // Name implements the rscsrv.Service interface.
@@ -17,7 +17,7 @@ func (srv *QueryCollectorService) Name() string {
 }
 
 func (service *QueryCollectorService) Start() error {
-	service.QueryCollector = promquery.NewQueryCollector(&promquery.QueryCollectorOpts{
+	service.QueryCollector = promsql.NewQueryCollector(&promsql.QueryCollectorOpts{
 		Prefix: "query_collector",
 	})
 

--- a/promfasthttp/fasthttp_test.go
+++ b/promfasthttp/fasthttp_test.go
@@ -119,7 +119,7 @@ name{constname="constvalue",labelname="val2"} 1
 # HELP promfasthttp_metric_handler_errors_total Total number of internal errors encountered by the promfasthttp metric handler.
 # TYPE promfasthttp_metric_handler_errors_total counter
 promfasthttp_metric_handler_errors_total{cause="encoding"} 0
-promfasthttp_metric_handler_errors_total{cause="gathering"} 1
+promfasthttp_metric_handler_errors_total{cause="gathering"} 0
 # HELP the_count Ah-ah-ah! Thunder and lightning!
 # TYPE the_count counter
 the_count 0
@@ -134,7 +134,7 @@ name{constname="constvalue",labelname="val2"} 1
 # HELP promfasthttp_metric_handler_errors_total Total number of internal errors encountered by the promfasthttp metric handler.
 # TYPE promfasthttp_metric_handler_errors_total counter
 promfasthttp_metric_handler_errors_total{cause="encoding"} 0
-promfasthttp_metric_handler_errors_total{cause="gathering"} 2
+promfasthttp_metric_handler_errors_total{cause="gathering"} 1
 # HELP the_count Ah-ah-ah! Thunder and lightning!
 # TYPE the_count counter
 the_count 0
@@ -156,10 +156,17 @@ the_count 0
 			ctx := createRequestCtx("GET", "/continue")
 			ctx.Request.Header.Add("Accept", "text/plain")
 			continueHandler(ctx)
+			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusOK))
+			Expect(logBuf.String()).To(Equal(wantMsg))
+			Expect(string(ctx.Response.Body())).To(Equal(wantOKBody1))
+
+			logBuf.Reset()
+			ctx.Response.Reset()
+			continueHandler(ctx)
 
 			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusOK))
 			Expect(logBuf.String()).To(Equal(wantMsg))
-			Expect(string(ctx.Response.Body())).To(Or(Equal(wantOKBody1), Equal(wantOKBody2)))
+			Expect(string(ctx.Response.Body())).To(Equal(wantOKBody2))
 		})
 
 		It("should panic on error", func() {

--- a/promsql/named_query.go
+++ b/promsql/named_query.go
@@ -1,10 +1,10 @@
-package promquery
+package promsql
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type NamedQueryCollector struct {
+type NamedQuery struct {
 	parent            *QueryCollector
 	name              string
 	TotalCalls        prometheus.Counter

--- a/promsql/query_collector.go
+++ b/promsql/query_collector.go
@@ -13,7 +13,7 @@ import (
 type QueryCollector struct {
 	totalCalls        *prometheus.CounterVec
 	totalDuration     *prometheus.CounterVec
-	totalSuccess      *prometheus.CounterVec
+	totalSuccesses    *prometheus.CounterVec
 	totalFailures     *prometheus.CounterVec
 	totalRowsAffected *prometheus.CounterVec
 }
@@ -48,14 +48,14 @@ func NewQueryCollector(opts *QueryCollectorOpts) *QueryCollector {
 		),
 		totalDuration: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("namedqry_%stotal_duration", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_duration_seconds", prefix),
 				Help: "The total duration (in seconds) from a query processed",
 			},
 			queryCollectorLabels,
 		),
-		totalSuccess: prometheus.NewCounterVec(
+		totalSuccesses: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprintf("namedqry_%stotal_success", prefix),
+				Name: fmt.Sprintf("namedqry_%stotal_successes", prefix),
 				Help: "The total number of a query processed with success",
 			},
 			queryCollectorLabels,
@@ -85,7 +85,7 @@ func (collector *QueryCollector) NewNamedQuery(name string) *NamedQuery {
 		name:              name,
 		TotalCalls:        collector.totalCalls.WithLabelValues(name),
 		TotalDuration:     collector.totalDuration.WithLabelValues(name),
-		TotalSuccess:      collector.totalSuccess.WithLabelValues(name),
+		TotalSuccess:      collector.totalSuccesses.WithLabelValues(name),
 		TotalFailures:     collector.totalFailures.WithLabelValues(name),
 		TotalRowsAffected: collector.totalRowsAffected.WithLabelValues(name),
 	}
@@ -115,7 +115,7 @@ func (collector *QueryCollector) NamedQuery(name string) QueryHandler {
 func (collector *QueryCollector) Describe(ch chan<- *prometheus.Desc) {
 	collector.totalCalls.Describe(ch)
 	collector.totalDuration.Describe(ch)
-	collector.totalSuccess.Describe(ch)
+	collector.totalSuccesses.Describe(ch)
 	collector.totalFailures.Describe(ch)
 	collector.totalRowsAffected.Describe(ch)
 }
@@ -124,7 +124,7 @@ func (collector *QueryCollector) Describe(ch chan<- *prometheus.Desc) {
 func (collector *QueryCollector) Collect(metrics chan<- prometheus.Metric) {
 	collector.totalCalls.Collect(metrics)
 	collector.totalDuration.Collect(metrics)
-	collector.totalSuccess.Collect(metrics)
+	collector.totalSuccesses.Collect(metrics)
 	collector.totalFailures.Collect(metrics)
 	collector.totalRowsAffected.Collect(metrics)
 }

--- a/promsql/sql_query.go
+++ b/promsql/sql_query.go
@@ -4,22 +4,25 @@ import (
 	"context"
 	"database/sql"
 	"time"
-
-	"github.com/lab259/go-rscsrv-prometheus/promquery"
 )
 
-type PromSQLQuery struct {
-	namedQuery *promquery.NamedQueryCollector
+// Query will serve as `sql.DB` and `sql.Tx` proxy. So, it can be
+// intialized and used as replacement for db or tx calls.
+type Query struct {
+	namedQuery *NamedQuery
 	db         DBQueryProxy
 }
 
-func NewSQLQuery(namedQuery *promquery.NamedQueryCollector, db DBQueryProxy) *PromSQLQuery {
-	return &PromSQLQuery{
+// NewQuery creates a new instance of *Query.
+func NewQuery(namedQuery *NamedQuery, db DBQueryProxy) *Query {
+	return &Query{
 		namedQuery: namedQuery,
 		db:         db,
 	}
 }
 
+// DBQueryProxy is an abstraction of the operations needed from the `sql.DB`.
+// Additionally, this approach enables using `sql.Tx` using the same strategy.
 type DBQueryProxy interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
@@ -27,7 +30,10 @@ type DBQueryProxy interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 }
 
-func (srv *PromSQLQuery) Query(query string, args ...interface{}) (*sql.Rows, error) {
+// Query is a proxy to `sql.DB.Query` that add some logic to count the number of
+// times the method was called, how many times it succeeded or failed and how
+// long it took.
+func (srv *Query) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	srv.namedQuery.TotalCalls.Inc()
 
 	start := time.Now()
@@ -43,7 +49,10 @@ func (srv *PromSQLQuery) Query(query string, args ...interface{}) (*sql.Rows, er
 	return res, err
 }
 
-func (srv *PromSQLQuery) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+// QueryContext is a proxy to `sql.DB.QueryContext` that add some logic to count
+// the number of times the method was called, how many times it succeeded or
+// failed and how long it took.
+func (srv *Query) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	srv.namedQuery.TotalCalls.Inc()
 
 	start := time.Now()
@@ -59,7 +68,10 @@ func (srv *PromSQLQuery) QueryContext(ctx context.Context, query string, args ..
 	return res, err
 }
 
-func (srv *PromSQLQuery) Exec(Exec string, args ...interface{}) (sql.Result, error) {
+// Exec is a proxy to `sql.DB.Exec` that add some logic to count the number of
+// times the method was called, how many times it succeeded or failed and how
+// long it took.
+func (srv *Query) Exec(Exec string, args ...interface{}) (sql.Result, error) {
 	srv.namedQuery.TotalCalls.Inc()
 
 	start := time.Now()
@@ -82,7 +94,10 @@ func (srv *PromSQLQuery) Exec(Exec string, args ...interface{}) (sql.Result, err
 	return res, err
 }
 
-func (srv *PromSQLQuery) ExecContext(ctx context.Context, Exec string, args ...interface{}) (sql.Result, error) {
+// ExecContext is a proxy to `sql.DB.ExecContext` that add some logic to count
+// the number of times the method was called, how many times it succeeded or
+// failed and how long it took.
+func (srv *Query) ExecContext(ctx context.Context, Exec string, args ...interface{}) (sql.Result, error) {
 	srv.namedQuery.TotalCalls.Inc()
 
 	start := time.Now()


### PR DESCRIPTION
### :recycle: Refactoring

* Unify promsql and promquery into one package: promsql;
* Renames metric `db_*_total_success` to `db_*_total_successes`;
* Renames metric `db_*_total_duration` to `db_*_total_duration_seconds`;
* Reflect changes to tests and examples;

### :sparkles: Enhacements

* Creates a new `QueryCollector.NamedQuery` method that is a high order function to help dealing with named queries.

### :pencil: Documentation

* Add some go documentation to the `QueryCollector` methods;
